### PR TITLE
refactor: centralize get_historical_vix

### DIFF
--- a/quant_desk_tools/__init__.py
+++ b/quant_desk_tools/__init__.py
@@ -1,17 +1,6 @@
-import numpy as np
-import pandas as pd
-import yfinance as yf
+"""Convenience exports for ``quant_desk_tools``."""
 
+from .vix_calculator import get_historical_vix
 
-def get_historical_vix(ticker, window=30, start=None, end=None):
-    """
-    Computes VIX-style (annualized window-day rolling historical volatility) for any ticker.
-    Returns: pd.DataFrame with Date and VIX columns.
-    """
-    df = yf.download(ticker, start=start, end=end, auto_adjust=True)
-    df['Return'] = np.log(df['Close'] / df['Close'].shift(1))
-    df['RealizedVol'] = df['Return'].rolling(window).std() * np.sqrt(252)  # annualized
-    df['VIX'] = df['RealizedVol'] * 100  # convert to percent
-    vix_df = df[['VIX']].dropna().reset_index()
-    return vix_df
+__all__ = ["get_historical_vix"]
 

--- a/quant_desk_tools/straddle.py
+++ b/quant_desk_tools/straddle.py
@@ -1,18 +1,6 @@
-import numpy as np
-import pandas as pd
-import yfinance as yf
+"""Example script demonstrating usage of ``get_historical_vix``."""
 
-def get_historical_vix(ticker, window=30, start=None, end=None):
-    """
-    Computes VIX-style (annualized window-day rolling historical volatility) for any ticker.
-    Returns: pd.DataFrame with Date and VIX columns.
-    """
-    df = yf.download(ticker, start=start, end=end, auto_adjust=True)
-    df['Return'] = np.log(df['Close'] / df['Close'].shift(1))
-    df['RealizedVol'] = df['Return'].rolling(window).std() * np.sqrt(252)  # annualized
-    df['VIX'] = df['RealizedVol'] * 100  # convert to percent
-    vix_df = df[['VIX']].dropna().reset_index()
-    return vix_df
+from .vix_calculator import get_historical_vix
 
 # Optional: direct script test (does nothing unless run as script)
 if __name__ == "__main__":

--- a/vix_dashboard.py
+++ b/vix_dashboard.py
@@ -2,7 +2,7 @@ import streamlit as st
 import yfinance as yf
 import pandas as pd
 import numpy as np
-from quant_desk_tools.vix_calculator import get_historical_vix
+from quant_desk_tools import get_historical_vix
 from quant_desk_tools.black_scholes import black_scholes_price
 
 def assign_single_column(df, column_name, data):


### PR DESCRIPTION
## Summary
- remove duplicate get_historical_vix implementations
- re-export helper from package root
- update example straddle script
- update VIX dashboard import

## Testing
- `pip install pandas yfinance numpy polars sqlalchemy lxml streamlit plotly pytest -q`
- `export PYTHONPATH=$PWD/src`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682e67d8b8832da4f17235f4d6918b