### PR TITLE
Add missing module docstrings

### DIFF
--- a/quant_desk_tools/black_scholes.py
+++ b/quant_desk_tools/black_scholes.py
@@ -1,3 +1,5 @@
+"""Utility functions for pricing options using the Black-Scholes model."""
+
 import numpy as np
 from scipy.stats import norm
 

--- a/quant_desk_tools/vix_calculator.py
+++ b/quant_desk_tools/vix_calculator.py
@@ -1,5 +1,6 @@
+"""Compute historical volatility metrics similar to the VIX index."""
+
 import numpy as np
-import pandas as pd
 import yfinance as yf
 
 def get_historical_vix(ticker, window=30, start=None, end=None):

--- a/src/quant_trading_strategy_backtester/__init__.py
+++ b/src/quant_trading_strategy_backtester/__init__.py
@@ -1,0 +1,2 @@
+"""Package exposing core backtesting functionality."""
+

--- a/src/quant_trading_strategy_backtester/__main__.py
+++ b/src/quant_trading_strategy_backtester/__main__.py
@@ -1,3 +1,5 @@
+"""Entry point for running the Streamlit application via ``python -m``."""
+
 from . import app
 
 if __name__ == "__main__":

--- a/src/quant_trading_strategy_backtester/models.py
+++ b/src/quant_trading_strategy_backtester/models.py
@@ -1,3 +1,5 @@
+"""SQLAlchemy models used for storing backtest results."""
+
 import datetime
 
 from sqlalchemy import (

--- a/src/quant_trading_strategy_backtester/strategies/__init__.py
+++ b/src/quant_trading_strategy_backtester/strategies/__init__.py
@@ -1,0 +1,2 @@
+"""Collection of strategy implementations bundled with the package."""
+

--- a/vix_dashboard.py
+++ b/vix_dashboard.py
@@ -1,3 +1,5 @@
+"""Streamlit dashboard for viewing implied and historical volatility."""
+
 import streamlit as st
 import yfinance as yf
 import pandas as pd


### PR DESCRIPTION
## Summary
- add module docstring to option pricing helpers
- explain VIX calculator module
- document Streamlit dashboard
- document packages and entry point modules
- document database models

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68682feb6878832db014fa1044b75052