### PR TITLE
Refactor optimiser modules

### DIFF
--- a/src/quant_trading_strategy_backtester/app.py
+++ b/src/quant_trading_strategy_backtester/app.py
@@ -12,7 +12,7 @@ import streamlit as st
 import streamlit.web.cli as stcli
 
 from quant_trading_strategy_backtester.data import get_full_company_name
-from quant_trading_strategy_backtester.optimiser import run_backtest
+from quant_trading_strategy_backtester.backtest_runner import run_backtest
 from quant_trading_strategy_backtester.results_history import display_historical_results
 from quant_trading_strategy_backtester.strategy_preparation import (
     prepare_pairs_trading_strategy_with_optimisation,

--- a/src/quant_trading_strategy_backtester/backtest_runner.py
+++ b/src/quant_trading_strategy_backtester/backtest_runner.py
@@ -1,0 +1,54 @@
+"""Utility functions for running backtests and creating strategy instances."""
+
+from typing import Any, List, Union
+
+import polars as pl
+
+from quant_trading_strategy_backtester.backtester import Backtester
+from quant_trading_strategy_backtester.strategies.base import (
+    TRADING_STRATEGIES,
+    BaseStrategy,
+)
+from quant_trading_strategy_backtester.strategies.buy_and_hold import BuyAndHoldStrategy
+from quant_trading_strategy_backtester.strategies.mean_reversion import (
+    MeanReversionStrategy,
+)
+from quant_trading_strategy_backtester.strategies.moving_average_crossover import (
+    MovingAverageCrossoverStrategy,
+)
+from quant_trading_strategy_backtester.strategies.pairs_trading import (
+    PairsTradingStrategy,
+)
+
+
+def run_backtest(
+    data: pl.DataFrame,
+    strategy_type: str,
+    strategy_params: dict[str, Any],
+    tickers: Union[str, List[str]],
+) -> tuple[pl.DataFrame, dict]:
+    """Execute the backtest using the given strategy and parameters."""
+    strategy = create_strategy(strategy_type, strategy_params)
+    backtester = Backtester(data, strategy, tickers=tickers)
+    results = backtester.run()
+    metrics = backtester.get_performance_metrics()
+    assert metrics is not None, "No results available for the selected ticker and date range"
+    return results, metrics
+
+
+def create_strategy(strategy_type: str, strategy_params: dict[str, Any]) -> BaseStrategy:
+    """Create a trading strategy instance based on ``strategy_type``."""
+    if strategy_type not in TRADING_STRATEGIES:
+        raise ValueError("Invalid strategy type")
+
+    match strategy_type:
+        case "Buy and Hold":
+            return BuyAndHoldStrategy(strategy_params)
+        case "Moving Average Crossover":
+            return MovingAverageCrossoverStrategy(strategy_params)
+        case "Mean Reversion":
+            return MeanReversionStrategy(strategy_params)
+        case "Pairs Trading":
+            return PairsTradingStrategy(strategy_params)
+        case _:
+            raise ValueError(f"Unexpected strategy type: {strategy_type}")

--- a/src/quant_trading_strategy_backtester/optimiser.py
+++ b/src/quant_trading_strategy_backtester/optimiser.py
@@ -4,35 +4,25 @@ parameters and ticker pairs.
 """
 
 import datetime
-import itertools
 import time
 from typing import Any, cast
 
 import polars as pl
 import streamlit as st
 
-from quant_trading_strategy_backtester.backtester import Backtester
-from quant_trading_strategy_backtester.data import (
-    get_top_sp500_companies,
-    is_same_company,
-    load_yfinance_data_one_ticker,
-    load_yfinance_data_two_tickers,
-)
-from quant_trading_strategy_backtester.strategies.base import (
-    TRADING_STRATEGIES,
-    BaseStrategy,
-)
-from quant_trading_strategy_backtester.strategies.buy_and_hold import BuyAndHoldStrategy
-from quant_trading_strategy_backtester.strategies.mean_reversion import (
-    MeanReversionStrategy,
-)
-from quant_trading_strategy_backtester.strategies.moving_average_crossover import (
-    MovingAverageCrossoverStrategy,
-)
-from quant_trading_strategy_backtester.strategies.pairs_trading import (
-    PairsTradingStrategy,
-)
+from quant_trading_strategy_backtester.data import get_top_sp500_companies
 from quant_trading_strategy_backtester.utils import NUM_TOP_COMPANIES_ONE_TICKER
+import quant_trading_strategy_backtester.optimiser_core as optimiser_core
+from quant_trading_strategy_backtester.optimiser_core import (
+    optimise_buy_and_hold_ticker,
+    optimise_pairs_trading_tickers,
+    optimise_single_ticker_strategy_ticker,
+    optimise_strategy_params,
+)
+from quant_trading_strategy_backtester.backtest_runner import (
+    run_backtest,
+    create_strategy,
+)
 
 
 def run_optimisation(
@@ -69,7 +59,7 @@ def run_optimisation(
         )
         st.success(f"Best ticker for Buy and Hold: {best_ticker}")
     else:
-        strategy_params, metrics = optimise_strategy_params(
+        strategy_params, metrics = optimiser_core.optimise_strategy_params(
             data,
             strategy_type,
             cast(dict[str, range | list[int | float]], strategy_params),
@@ -86,308 +76,12 @@ def run_optimisation(
     return strategy_params, metrics
 
 
-def optimise_buy_and_hold_ticker(
-    top_companies: list[tuple[str, float]],
-    start_date: datetime.date,
-    end_date: datetime.date,
-) -> tuple[str, dict[str, Any], dict[str, float]]:
-    """
-    Optimises ticker selection for the Buy and Hold strategy.
-
-    Args:
-        top_companies: List of tuples containing ticker symbols and market caps
-                       of top companies.
-        start_date: Start date for historical data.
-        end_date: End date for historical data.
-
-    Returns:
-        A tuple containing the best ticker, strategy parameters, and
-        performance metrics.
-    """
-    best_ticker = None
-    best_metrics = None
-    best_total_return = float("-inf")
-
-    total_tickers = len(top_companies)
-    progress_bar = st.progress(0)
-    status_text = st.empty()
-
-    for i, (ticker, _) in enumerate(top_companies):
-        status_text.text(f"Evaluating ticker {i + 1} / {total_tickers}: {ticker}")
-        progress_bar.progress((i + 1) / total_tickers)
-
-        data = load_yfinance_data_one_ticker(ticker, start_date, end_date)
-        if data is None or data.is_empty():
-            continue
-
-        strategy = BuyAndHoldStrategy({})
-        backtester = Backtester(data, strategy, tickers=ticker)
-        backtester.run()
-        metrics = backtester.get_performance_metrics()
-
-        if metrics and metrics["Total Return"] > best_total_return:
-            best_total_return = metrics["Total Return"]
-            best_ticker = ticker
-            best_metrics = metrics
-
-    progress_bar.empty()
-    status_text.empty()
-
-    if not best_ticker or not best_metrics:
-        raise ValueError("Buy and Hold optimisation failed")
-
-    return best_ticker, {}, best_metrics
-
-
-def optimise_single_ticker_strategy_ticker(
-    top_companies: list[tuple[str, float]],
-    start_date: datetime.date,
-    end_date: datetime.date,
-    strategy_type: str,
-    strategy_params: dict[str, Any],
-) -> str:
-    """
-    Optimises ticker selection for single ticker strategies.
-
-    Args:
-        top_companies: List of tuples containing ticker symbols and market caps
-                       of top companies.
-        start_date: Start date for historical data.
-        end_date: End date for historical data.
-        strategy_type: The type of strategy being used.
-        strategy_params: Strategy parameters.
-
-    Returns:
-        The best ticker.
-    """
-    best_ticker = None
-    best_sharpe_ratio = float("-inf")
-
-    total_tickers = len(top_companies)
-    progress_bar = st.progress(0)
-    status_text = st.empty()
-
-    # Use fixed parameter values for ticker evaluation
-    fixed_params = {
-        k: v[0] if isinstance(v, (list, range)) else v
-        for k, v in strategy_params.items()
-    }
-
-    for i, (ticker, _) in enumerate(top_companies):
-        status_text.text(f"Evaluating ticker {i + 1} / {total_tickers}: {ticker}")
-        progress_bar.progress((i + 1) / total_tickers)
-
-        data = load_yfinance_data_one_ticker(ticker, start_date, end_date)
-        if data is None or data.is_empty():
-            continue
-
-        _, current_metrics = run_backtest(data, strategy_type, fixed_params, ticker)
-
-        if current_metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = current_metrics["Sharpe Ratio"]
-            best_ticker = ticker
-
-    progress_bar.empty()
-    status_text.empty()
-
-    if not best_ticker:
-        raise ValueError("Single ticker strategy ticker optimisation failed")
-
-    return best_ticker
-
-
-def optimise_strategy_params(
-    data: pl.DataFrame,
-    strategy_type: str,
-    parameter_ranges: dict[str, range | list[int | float]],
-    tickers: str | list[str],
-) -> tuple[dict[str, int | float], dict[str, float]]:
-    """
-    Optimises strategy parameters by testing all combinations within given
-    ranges.
-
-    Args:
-        data: Historical price data.
-        strategy_type: The type of strategy to optimise.
-        parameter_ranges: A dictionary of parameters and their possible values
-                          to test.
-        tickers: The ticker or tickers used in the backtest.
-
-    Returns:
-        A tuple containing the best parameters and their performance metrics.
-    """
-    best_params = None
-    best_metrics = None
-    best_sharpe_ratio = float("-inf")
-
-    param_names = list(parameter_ranges.keys())
-    param_values = [
-        list(value) if isinstance(value, range) else value
-        for value in parameter_ranges.values()
-    ]
-
-    param_combinations = list(itertools.product(*param_values))
-    total_combinations = len(param_combinations)
-    # Display progress bar and status text, as this process may take a while.
-    progress_bar = st.progress(0)
-    status_text = st.empty()
-
-    for i, params in enumerate(param_combinations):
-        status_text.text(
-            f"Evaluating parameter combination {i + 1} / {total_combinations}"
-        )
-        progress_bar.progress((i + 1) / total_combinations)
-
-        current_params = dict(zip(param_names, params))
-        _, metrics = run_backtest(data, strategy_type, current_params, tickers)
-
-        if metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = metrics["Sharpe Ratio"]
-            best_params = current_params
-            best_metrics = metrics
-
-    progress_bar.empty()
-    status_text.empty()
-    if not best_params or not best_metrics:
-        raise ValueError("Parameter optimisation failed")
-
-    return best_params, best_metrics
-
-
-def optimise_pairs_trading_tickers(
-    top_companies: list[tuple[str, float]],
-    start_date: datetime.date,
-    end_date: datetime.date,
-    strategy_params: dict[str, Any],
-    optimise: bool,
-) -> tuple[tuple[str, str], dict[str, Any], dict[str, float]]:
-    """
-    Optimises ticker pair selection and strategy parameters for pairs trading.
-
-    Args:
-        top_companies: List of tuples containing ticker symbols and market caps
-                       of top companies.
-        start_date: Start date for historical data.
-        end_date: End date for historical data.
-        strategy_params: Strategy parameters or parameter ranges.
-        optimise: Whether to optimise the strategy parameters.
-
-    Returns:
-        A tuple containing the best ticker pair, best parameters, and best
-        metrics.
-    """
-    best_pair = None
-    best_params = None
-    best_metrics = None
-    best_sharpe_ratio = float("-inf")
-
-    ticker_pairs = list(
-        itertools.combinations([company[0] for company in top_companies], 2)
-    )
-    # Filter out pairs that likely represent the same company
-    ticker_pairs = [
-        pair for pair in ticker_pairs if not is_same_company(pair[0], pair[1])
-    ]
-    total_combinations = len(ticker_pairs)
-    # Display progress bar and status text, as this process may take a while.
-    progress_bar = st.progress(0)
-    status_text = st.empty()
-    prev_pair_processing_time = 0.0
-
-    for i, (ticker1, ticker2) in enumerate(ticker_pairs):
-        start_time = time.time()
-        status_text.text(
-            f"Evaluating pair {i + 1} / {total_combinations}: {ticker1} vs. {ticker2} "
-            f"(prev. pair processing time: {prev_pair_processing_time:.4f} seconds)"
-        )
-        progress_bar.progress((i + 1) / total_combinations)
-
-        data = load_yfinance_data_two_tickers(ticker1, ticker2, start_date, end_date)
-        if data is None or data.is_empty():
-            continue
-
-        if optimise:
-            # Convert single values to lists for optimisation
-            param_ranges = {
-                k: [v] if isinstance(v, (int, float)) else v
-                for k, v in strategy_params.items()
-            }
-            current_params, current_metrics = optimise_strategy_params(
-                data, "Pairs Trading", param_ranges, [ticker1, ticker2]
-            )
-        else:
-            _, current_metrics = run_backtest(
-                data, "Pairs Trading", strategy_params, [ticker1, ticker2]
-            )
-            current_params = strategy_params
-
-        if current_metrics["Sharpe Ratio"] > best_sharpe_ratio:
-            best_sharpe_ratio = current_metrics["Sharpe Ratio"]
-            best_pair = (ticker1, ticker2)
-            best_params = current_params
-            best_metrics = current_metrics
-
-        end_time = time.time()
-        prev_pair_processing_time = end_time - start_time
-
-    progress_bar.empty()
-    status_text.empty()
-    if not best_pair or not best_params or not best_metrics:
-        raise ValueError("Pairs trading optimisation failed")
-
-    return best_pair, best_params, best_metrics
-
-
-def run_backtest(
-    data: pl.DataFrame,
-    strategy_type: str,
-    strategy_params: dict[str, Any],
-    tickers: str | list[str],
-) -> tuple[pl.DataFrame, dict]:
-    """
-    Executes the backtest using the selected strategy and parameters.
-
-    Args:
-        data: Historical stock data.
-        strategy_type: The type of strategy to use for the backtest.
-        strategy_params: Additional parameters required for the strategy.
-        tickers: The ticker or tickers used in the backtest.
-
-    Returns:
-        A tuple containing the backtest results DataFrame and performance metrics.
-    """
-    strategy = create_strategy(strategy_type, strategy_params)
-    backtester = Backtester(data, strategy, tickers=tickers)
-    results = backtester.run()
-    metrics = backtester.get_performance_metrics()
-    assert (
-        metrics is not None
-    ), "No results available for the selected ticker and date range"
-
-    return results, metrics
-
-
-def create_strategy(
-    strategy_type: str, strategy_params: dict[str, Any]
-) -> BaseStrategy:
-    """
-    Creates a trading strategy object based on the selected strategy type.
-
-    Args:
-        strategy_type: The type of trading strategy.
-        strategy_params: A dictionary containing the strategy parameters.
-    """
-    if strategy_type not in TRADING_STRATEGIES:
-        raise ValueError("Invalid strategy type")
-
-    match strategy_type:
-        case "Buy and Hold":
-            return BuyAndHoldStrategy(strategy_params)
-        case "Moving Average Crossover":
-            return MovingAverageCrossoverStrategy(strategy_params)
-        case "Mean Reversion":
-            return MeanReversionStrategy(strategy_params)
-        case "Pairs Trading":
-            return PairsTradingStrategy(strategy_params)
-        case _:
-            raise ValueError(f"Unexpected strategy type: {strategy_type}")
+__all__ = [
+    "run_optimisation",
+    "optimise_buy_and_hold_ticker",
+    "optimise_single_ticker_strategy_ticker",
+    "optimise_strategy_params",
+    "optimise_pairs_trading_tickers",
+    "run_backtest",
+    "create_strategy",
+]

--- a/src/quant_trading_strategy_backtester/optimiser_core.py
+++ b/src/quant_trading_strategy_backtester/optimiser_core.py
@@ -1,0 +1,199 @@
+"""Core optimisation routines used by the Streamlit app and preparation helpers."""
+
+from __future__ import annotations
+
+import datetime
+import itertools
+import time
+from typing import Any, List, Tuple, Union
+
+import polars as pl
+import streamlit as st
+
+from quant_trading_strategy_backtester.backtest_runner import run_backtest
+from quant_trading_strategy_backtester.data import (
+    load_yfinance_data_one_ticker,
+    load_yfinance_data_two_tickers,
+    is_same_company,
+)
+from quant_trading_strategy_backtester.strategies.buy_and_hold import BuyAndHoldStrategy
+
+
+def optimise_buy_and_hold_ticker(
+    top_companies: List[Tuple[str, float]],
+    start_date: datetime.date,
+    end_date: datetime.date,
+) -> tuple[str, dict[str, Any], dict[str, float]]:
+    """Return the best ticker for the Buy and Hold strategy."""
+    best_ticker = None
+    best_metrics = None
+    best_total_return = float("-inf")
+
+    total_tickers = len(top_companies)
+    progress_bar = st.progress(0)
+    status_text = st.empty()
+
+    for i, (ticker, _) in enumerate(top_companies):
+        status_text.text(f"Evaluating ticker {i + 1} / {total_tickers}: {ticker}")
+        progress_bar.progress((i + 1) / total_tickers)
+
+        data = load_yfinance_data_one_ticker(ticker, start_date, end_date)
+        if data is None or data.is_empty():
+            continue
+
+        strategy = BuyAndHoldStrategy({})
+        backtester = run_backtest(data, "Buy and Hold", {}, ticker)
+        # run_backtest returns (results, metrics)
+        _, metrics = backtester
+
+        if metrics and metrics["Total Return"] > best_total_return:
+            best_total_return = metrics["Total Return"]
+            best_ticker = ticker
+            best_metrics = metrics
+
+    progress_bar.empty()
+    status_text.empty()
+
+    if not best_ticker or not best_metrics:
+        raise ValueError("Buy and Hold optimisation failed")
+
+    return best_ticker, {}, best_metrics
+
+
+def optimise_single_ticker_strategy_ticker(
+    top_companies: List[Tuple[str, float]],
+    start_date: datetime.date,
+    end_date: datetime.date,
+    strategy_type: str,
+    strategy_params: dict[str, Any],
+) -> str:
+    """Find the best ticker for single ticker strategies."""
+    best_ticker = None
+    best_sharpe_ratio = float("-inf")
+
+    total_tickers = len(top_companies)
+    progress_bar = st.progress(0)
+    status_text = st.empty()
+
+    fixed_params = {
+        k: v[0] if isinstance(v, (list, range)) else v for k, v in strategy_params.items()
+    }
+
+    for i, (ticker, _) in enumerate(top_companies):
+        status_text.text(f"Evaluating ticker {i + 1} / {total_tickers}: {ticker}")
+        progress_bar.progress((i + 1) / total_tickers)
+
+        data = load_yfinance_data_one_ticker(ticker, start_date, end_date)
+        if data is None or data.is_empty():
+            continue
+
+        _, current_metrics = run_backtest(data, strategy_type, fixed_params, ticker)
+
+        if current_metrics["Sharpe Ratio"] > best_sharpe_ratio:
+            best_sharpe_ratio = current_metrics["Sharpe Ratio"]
+            best_ticker = ticker
+
+    progress_bar.empty()
+    status_text.empty()
+
+    if not best_ticker:
+        raise ValueError("Single ticker strategy ticker optimisation failed")
+
+    return best_ticker
+
+
+def optimise_strategy_params(
+    data: pl.DataFrame,
+    strategy_type: str,
+    parameter_ranges: dict[str, Union[range, list[int | float]]],
+    tickers: Union[str, List[str]],
+) -> tuple[dict[str, int | float], dict[str, float]]:
+    """Search parameter ranges and return the best parameter set."""
+    best_params = None
+    best_metrics = None
+    best_sharpe_ratio = float("-inf")
+
+    param_names = list(parameter_ranges.keys())
+    param_values = [list(value) if isinstance(value, range) else value for value in parameter_ranges.values()]
+
+    param_combinations = list(itertools.product(*param_values))
+    total_combinations = len(param_combinations)
+    progress_bar = st.progress(0)
+    status_text = st.empty()
+
+    for i, params in enumerate(param_combinations):
+        status_text.text(f"Evaluating parameter combination {i + 1} / {total_combinations}")
+        progress_bar.progress((i + 1) / total_combinations)
+
+        current_params = dict(zip(param_names, params))
+        _, metrics = run_backtest(data, strategy_type, current_params, tickers)
+
+        if metrics["Sharpe Ratio"] > best_sharpe_ratio:
+            best_sharpe_ratio = metrics["Sharpe Ratio"]
+            best_params = current_params
+            best_metrics = metrics
+
+    progress_bar.empty()
+    status_text.empty()
+    if not best_params or not best_metrics:
+        raise ValueError("Parameter optimisation failed")
+
+    return best_params, best_metrics
+
+
+def optimise_pairs_trading_tickers(
+    top_companies: List[Tuple[str, float]],
+    start_date: datetime.date,
+    end_date: datetime.date,
+    strategy_params: dict[str, Any],
+    optimise: bool,
+) -> tuple[tuple[str, str], dict[str, Any], dict[str, float]]:
+    """Search for the best ticker pair for pairs trading."""
+    best_pair = None
+    best_params = None
+    best_metrics = None
+    best_sharpe_ratio = float("-inf")
+
+    ticker_pairs = list(itertools.combinations([company[0] for company in top_companies], 2))
+    ticker_pairs = [pair for pair in ticker_pairs if not is_same_company(pair[0], pair[1])]
+    total_combinations = len(ticker_pairs)
+    progress_bar = st.progress(0)
+    status_text = st.empty()
+    prev_pair_processing_time = 0.0
+
+    for i, (ticker1, ticker2) in enumerate(ticker_pairs):
+        start_time = time.time()
+        status_text.text(
+            f"Evaluating pair {i + 1} / {total_combinations}: {ticker1} vs. {ticker2} "
+            f"(prev. pair processing time: {prev_pair_processing_time:.4f} seconds)"
+        )
+        progress_bar.progress((i + 1) / total_combinations)
+
+        data = load_yfinance_data_two_tickers(ticker1, ticker2, start_date, end_date)
+        if data is None or data.is_empty():
+            continue
+
+        if optimise:
+            param_ranges = {k: [v] if isinstance(v, (int, float)) else v for k, v in strategy_params.items()}
+            current_params, current_metrics = optimise_strategy_params(
+                data, "Pairs Trading", param_ranges, [ticker1, ticker2]
+            )
+        else:
+            _, current_metrics = run_backtest(data, "Pairs Trading", strategy_params, [ticker1, ticker2])
+            current_params = strategy_params
+
+        if current_metrics["Sharpe Ratio"] > best_sharpe_ratio:
+            best_sharpe_ratio = current_metrics["Sharpe Ratio"]
+            best_pair = (ticker1, ticker2)
+            best_params = current_params
+            best_metrics = current_metrics
+
+        end_time = time.time()
+        prev_pair_processing_time = end_time - start_time
+
+    progress_bar.empty()
+    status_text.empty()
+    if not best_pair or not best_params or not best_metrics:
+        raise ValueError("Pairs trading optimisation failed")
+
+    return best_pair, best_params, best_metrics

--- a/src/quant_trading_strategy_backtester/strategy_preparation.py
+++ b/src/quant_trading_strategy_backtester/strategy_preparation.py
@@ -14,12 +14,12 @@ from quant_trading_strategy_backtester.data import (
     load_yfinance_data_one_ticker,
     load_yfinance_data_two_tickers,
 )
-from quant_trading_strategy_backtester.optimiser import (
+from quant_trading_strategy_backtester.optimiser import run_optimisation
+from quant_trading_strategy_backtester.optimiser_core import (
     optimise_buy_and_hold_ticker,
     optimise_pairs_trading_tickers,
     optimise_single_ticker_strategy_ticker,
     optimise_strategy_params,
-    run_optimisation,
 )
 from quant_trading_strategy_backtester.utils import (
     NUM_TOP_COMPANIES_ONE_TICKER,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -107,25 +107,19 @@ def mock_yfinance_functions(monkeypatch):
         "quant_trading_strategy_backtester.strategy_preparation.load_yfinance_data_two_tickers",
         mock_load_two_tickers,
     )
-    monkeypatch.setattr(
-        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_one_ticker",
-        mock_load_one_ticker,
-    )
-    monkeypatch.setattr(
-        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_two_tickers",
-        mock_load_two_tickers,
-    )
 
 
 @pytest.fixture(autouse=True)
 def mock_yfinance_download(monkeypatch):
     def mock_download(*args, **kwargs):
+        dates = pd.date_range(start="2020-01-01", end="2020-12-31")
+        n = len(dates)
         return pd.DataFrame(
             {
-                "Date": pd.date_range(start="2020-01-01", end="2020-12-31"),
-                "Close": [100 + i * 0.1 for i in range(365)],
-                "Adj Close": [100 + i * 0.1 for i in range(365)],
-                "Volume": [1000000 for _ in range(365)],
+                "Date": dates,
+                "Close": [100 + i * 0.1 for i in range(n)],
+                "Adj Close": [100 + i * 0.1 for i in range(n)],
+                "Volume": [1000000 for _ in range(n)],
             }
         ).set_index("Date")
 

--- a/tests/test_optimiser_core.py
+++ b/tests/test_optimiser_core.py
@@ -33,11 +33,12 @@ def test_optimise_buy_and_hold_ticker(monkeypatch):
         return None, {"Total Return": 0.3, "Sharpe Ratio": 1.5, "Max Drawdown": -0.1}
 
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.data.load_yfinance_data_one_ticker",
+        "quant_trading_strategy_backtester.optimiser_core.load_yfinance_data_one_ticker",
         mock_load_data,
     )
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+        "quant_trading_strategy_backtester.optimiser_core.run_backtest",
+        mock_run_backtest,
     )
 
     start_date = datetime.date(2020, 1, 1)
@@ -171,11 +172,24 @@ def test_optimise_pairs_trading_tickers(monkeypatch):
         }
 
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.data.load_yfinance_data_two_tickers",
+        "quant_trading_strategy_backtester.optimiser_core.load_yfinance_data_two_tickers",
         mock_load_data,
     )
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.optimiser.run_backtest", mock_run_backtest
+        "quant_trading_strategy_backtester.optimiser_core.run_backtest",
+        mock_run_backtest,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.optimise_strategy_params",
+        mock_optimise_strategy_params,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser_core.optimise_strategy_params",
+        mock_optimise_strategy_params,
+    )
+    monkeypatch.setattr(
+        "quant_trading_strategy_backtester.optimiser.optimise_strategy_params",
+        mock_optimise_strategy_params,
     )
     monkeypatch.setattr(
         "quant_trading_strategy_backtester.optimiser.optimise_strategy_params",
@@ -288,7 +302,7 @@ def test_run_optimisation(monkeypatch):
         return {"window": 25, "std_dev": 2.5}, {"Sharpe Ratio": 1.8}
 
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.optimiser.optimise_strategy_params",
+        "quant_trading_strategy_backtester.optimiser_core.optimise_strategy_params",
         mock_optimise_strategy_params,
     )
 

--- a/tests/test_strategy_preparation.py
+++ b/tests/test_strategy_preparation.py
@@ -91,11 +91,11 @@ def test_optimise_single_ticker_strategy_ticker(monkeypatch):
             return None, {"Sharpe Ratio": 1.0}
 
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.optimiser.load_yfinance_data_one_ticker",
+        "quant_trading_strategy_backtester.optimiser_core.load_yfinance_data_one_ticker",
         mock_load_data,
     )
     monkeypatch.setattr(
-        "quant_trading_strategy_backtester.optimiser.run_backtest",
+        "quant_trading_strategy_backtester.optimiser_core.run_backtest",
         mock_run_backtest,
     )
 


### PR DESCRIPTION
## Summary
- split optimiser functions into `optimiser_core.py` and `backtest_runner.py`
- update `optimiser.py` to delegate to new modules
- adjust application and strategy prep imports
- update tests for new module paths
- run full test suite

## Testing
- `pip install -r requirements.txt`
- `pip install -e .`
- `pytest -q`
- `timeout 5 python -m quant_trading_strategy_backtester.app`

------
https://chatgpt.com/codex/tasks/task_e_686846e9ffc4832d8c47614fa780a3fc