### PR TITLE
Switch MA strategy to Triple EMA TEMO

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ _Try the deployed app
 
 - Buy and Hold
 - Mean Reversion
-- Moving Average Crossover
+- Triple EMA (TEMO) Crossover
 - Pairs Trading
 
 ## Key Features

--- a/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
+++ b/src/quant_trading_strategy_backtester/strategies/moving_average_crossover.py
@@ -1,7 +1,4 @@
-"""
-Implements the moving average crossover strategy, which is based on the
-crossover of short-term and long-term moving averages of the closing price.
-"""
+"""Triple EMA (TEMO) crossover strategy implementation."""
 
 from typing import Any
 
@@ -11,84 +8,142 @@ from quant_trading_strategy_backtester.strategies.base import BaseStrategy
 
 
 class MovingAverageCrossoverStrategy(BaseStrategy):
-    """
-    Implements the moving average crossover strategy, which is based on the
-    crossover of short-term and long-term moving averages of the closing price.
-    This strategy aims to identify and follows market trends. The short-term
-    moving average is more responsive to price changes, while the long-term
-    moving average represents the overall trend direction.
+    """Triple EMA (TEMO) crossover strategy.
 
-    Attributes:
-        params: A dictionary containing the strategy parameters.
+    The strategy enters long when the 10-period EMA crosses above the
+    80-period EMA and both the ADX and Chande Momentum Oscillator (CMO)
+    confirm strong momentum. Short entries use the opposite conditions.
+    Position size defaults to 3% of capital per trade.
     """
 
     def __init__(self, params: dict[str, Any]):
         super().__init__(params)
-        # The number of days for the short-term and long-term moving average.
-        self.short_window = int(params["short_window"])
-        self.long_window = int(params["long_window"])
+        self.position_size = float(params.get("position_size", 0.03))
+        self.adx_period = int(params.get("adx_period", 14))
+        self.cmo_period = int(params.get("cmo_period", 14))
+        self.atr_period = int(params.get("atr_period", 14))
+
+    def _calculate_indicators(self, df: pl.DataFrame) -> pl.DataFrame:
+        df = df.with_columns(
+            [
+                pl.col("Close").ewm_mean(span=10).alias("ema_10"),
+                pl.col("Close").ewm_mean(span=80).alias("ema_80"),
+                pl.col("Close").ewm_mean(span=20).alias("ema_20"),
+                pl.col("Close").ewm_mean(span=70).alias("ema_70"),
+            ]
+        )
+
+        true_range = pl.max_horizontal(
+            [
+                pl.col("High") - pl.col("Low"),
+                (pl.col("High") - pl.col("Close").shift(1)).abs(),
+                (pl.col("Low") - pl.col("Close").shift(1)).abs(),
+            ]
+        )
+        df = df.with_columns(true_range.alias("tr"))
+        df = df.with_columns(
+            pl.col("tr")
+            .rolling_mean(self.atr_period, min_periods=self.atr_period)
+            .alias("atr")
+        )
+
+        up_move = pl.col("High") - pl.col("High").shift(1)
+        down_move = pl.col("Low").shift(1) - pl.col("Low")
+        plus_dm = pl.when((up_move > down_move) & (up_move > 0)).then(up_move).otherwise(0)
+        minus_dm = pl.when((down_move > up_move) & (down_move > 0)).then(down_move).otherwise(0)
+        df = df.with_columns([plus_dm.alias("plus_dm"), minus_dm.alias("minus_dm")])
+        df = df.with_columns(
+            [
+                pl.col("plus_dm").rolling_sum(self.adx_period).alias("plus_dm_sum"),
+                pl.col("minus_dm").rolling_sum(self.adx_period).alias("minus_dm_sum"),
+            ]
+        )
+        df = df.with_columns(
+            [
+                (100 * pl.col("plus_dm_sum") / pl.col("atr")).alias("plus_di"),
+                (100 * pl.col("minus_dm_sum") / pl.col("atr")).alias("minus_di"),
+            ]
+        )
+        df = df.with_columns(
+            (
+                ((pl.col("plus_di") - pl.col("minus_di")).abs() / (pl.col("plus_di") + pl.col("minus_di")))
+                * 100
+            ).alias("dx")
+        )
+        df = df.with_columns(
+            pl.col("dx")
+            .rolling_mean(self.adx_period, min_periods=self.adx_period)
+            .alias("adx")
+        )
+
+        delta = pl.col("Close") - pl.col("Close").shift(1)
+        gains = pl.when(delta > 0).then(delta).otherwise(0)
+        losses = pl.when(delta < 0).then(-delta).otherwise(0)
+        df = df.with_columns([gains.alias("gain"), losses.alias("loss")])
+        df = df.with_columns(
+            [
+                pl.col("gain").rolling_sum(self.cmo_period).alias("gain_sum"),
+                pl.col("loss").rolling_sum(self.cmo_period).alias("loss_sum"),
+            ]
+        )
+        df = df.with_columns(
+            (
+                100
+                * (pl.col("gain_sum") - pl.col("loss_sum"))
+                / (pl.col("gain_sum") + pl.col("loss_sum"))
+            ).alias("cmo")
+        )
+        return df
 
     def generate_signals(self, data: pl.DataFrame) -> pl.DataFrame:
-        """
-        Generates trading signals for the given data.
-
-        A buy signal (1) is generated when the short-term moving average
-        crosses above the long-term moving average. The strategy maintains the
-        position until the short-term moving average crosses below the
-        long-term moving average.
-
-        Args:
-            data: A DataFrame containing the price data. Must have a 'Close'
-                  column.
-
-        Returns:
-            A DataFrame containing the generated trading signals. Columns
-            include 'signal', 'short_mavg', 'long_mavg', and 'positions'.
-        """
+        """Generate trading signals based on TEMO crossover rules."""
         if data.is_empty():
             return pl.DataFrame(
                 schema=[
                     ("Date", pl.Date),
                     ("Close", pl.Float64),
-                    ("short_mavg", pl.Float64),
-                    ("long_mavg", pl.Float64),
                     ("signal", pl.Float64),
                     ("positions", pl.Float64),
                 ]
             )
 
-        signals = data.select([pl.col("Date"), pl.col("Close")])
-        signals = signals.with_columns(
+        df = self._calculate_indicators(data)
+
+        long_cond = (
+            (pl.col("ema_10") > pl.col("ema_80"))
+            & (pl.col("adx") > 40)
+            & (pl.col("cmo") > 40)
+        )
+        short_cond = (
+            (pl.col("ema_10") < pl.col("ema_80"))
+            & (pl.col("adx") > 40)
+            & (pl.col("cmo") < -40)
+        )
+
+        df = df.with_columns(
+            pl.when(long_cond)
+            .then(1.0)
+            .when(short_cond)
+            .then(-1.0)
+            .otherwise(0.0)
+            .alias("signal")
+        )
+        df = df.with_columns(pl.col("signal").diff().fill_null(0.0).alias("positions"))
+        df = df.with_columns(pl.lit(self.position_size).alias("position_size"))
+
+        return df.select(
             [
-                pl.col("Close")
-                .rolling_mean(
-                    window_size=self.short_window, min_periods=self.short_window
-                )
-                .alias("short_mavg"),
-                pl.col("Close")
-                .rolling_mean(
-                    window_size=self.long_window, min_periods=self.long_window
-                )
-                .alias("long_mavg"),
-                pl.lit(0.0).alias("signal"),
+                "Date",
+                "Close",
+                "ema_10",
+                "ema_80",
+                "ema_20",
+                "ema_70",
+                "atr",
+                "adx",
+                "cmo",
+                "signal",
+                "positions",
+                "position_size",
             ]
         )
-
-        signals = signals.with_columns(
-            [
-                # If the short-term moving average is above the long-term moving
-                # average, generate a buy signal.
-                pl.when(pl.col("short_mavg") > pl.col("long_mavg"))
-                .then(1.0)
-                .otherwise(0.0)
-                .alias("signal")
-            ]
-        )
-
-        # If the short-term moving average is below the long-term moving
-        # average, generate a sell signal by setting all non-buy signals to -1.
-        signals = signals.with_columns(
-            [pl.col("signal").diff().fill_null(0.0).alias("positions")]
-        )
-
-        return signals

--- a/src/quant_trading_strategy_backtester/streamlit_ui.py
+++ b/src/quant_trading_strategy_backtester/streamlit_ui.py
@@ -90,10 +90,7 @@ def get_optimisation_ranges(strategy_type: str) -> dict[str, Any]:
 
     match strategy_type:
         case "Moving Average Crossover":
-            return {
-                "short_window": range(5, 51, 5),
-                "long_window": range(20, 201, 20),
-            }
+            return {"position_size": [0.01, 0.02, 0.03, 0.05]}
         case "Mean Reversion":
             return {
                 "window": range(5, 101, 5),
@@ -126,13 +123,14 @@ def get_fixed_params(strategy_type: str) -> dict[str, Any]:
 
     match strategy_type:
         case "Moving Average Crossover":
-            short_window = st.sidebar.slider(
-                "Short Window (Days)", min_value=5, max_value=50, value=20
+            position_size = st.sidebar.slider(
+                "Position Size (% of capital)",
+                min_value=0.01,
+                max_value=0.1,
+                value=0.03,
+                step=0.01,
             )
-            long_window = st.sidebar.slider(
-                "Long Window (Days)", min_value=20, max_value=200, value=50
-            )
-            return {"short_window": short_window, "long_window": long_window}
+            return {"position_size": position_size}
         case "Mean Reversion":
             window = st.sidebar.slider(
                 "Window (Days)", min_value=5, max_value=100, value=20

--- a/tests/strategies/test_base.py
+++ b/tests/strategies/test_base.py
@@ -22,7 +22,7 @@ from quant_trading_strategy_backtester.strategies.pairs_trading import (
 @pytest.mark.parametrize(
     "strategy_class,params",
     [
-        (MovingAverageCrossoverStrategy, {"short_window": 5, "long_window": 20}),
+        (MovingAverageCrossoverStrategy, {}),
         (MeanReversionStrategy, {"window": 5, "std_dev": 2.0}),
         (
             PairsTradingStrategy,

--- a/tests/strategies/test_moving_average_crossover.py
+++ b/tests/strategies/test_moving_average_crossover.py
@@ -12,23 +12,22 @@ from quant_trading_strategy_backtester.strategies.moving_average_crossover impor
 
 
 def test_moving_average_crossover_strategy_initialisation() -> None:
-    params = {"short_window": 5, "long_window": 20}
+    params = {"position_size": 0.05}
     strategy = MovingAverageCrossoverStrategy(params)
-    assert strategy.short_window == 5
-    assert strategy.long_window == 20
+    assert strategy.position_size == 0.05
 
 
 def test_moving_average_crossover_strategy_generate_signals(
     mock_polars_data: pl.DataFrame,
 ) -> None:
-    params = {"short_window": 5, "long_window": 20}
+    params = {}
     strategy = MovingAverageCrossoverStrategy(params)
     signals = strategy.generate_signals(mock_polars_data)
     assert isinstance(signals, pl.DataFrame)
-    EXPECTED_COLS = {"signal", "short_mavg", "long_mavg", "positions"}
+    EXPECTED_COLS = {"signal", "positions", "ema_10", "ema_80", "atr", "adx", "cmo"}
     for col in EXPECTED_COLS:
         assert col in signals.columns
-    assert signals["signal"].is_in([0.0, 1.0]).all()
+    assert signals["signal"].is_in([-1.0, 0.0, 1.0]).all()
 
 
 def test_moving_average_crossover_strategy_with_mock_polars_data():
@@ -41,46 +40,24 @@ def test_moving_average_crossover_strategy_with_mock_polars_data():
         150 - i for i in range(50)
     ]  # Downtrend
 
-    mock_polars_data = pl.DataFrame({"Date": dates, "Close": prices})
+    mock_polars_data = pl.DataFrame(
+        {
+            "Date": dates,
+            "Open": prices,
+            "High": [p + 1 for p in prices],
+            "Low": [p - 1 for p in prices],
+            "Close": prices,
+        }
+    )
 
     # Strategy parameters
-    params = {"short_window": 10, "long_window": 30}
-
+    params = {}
     strategy = MovingAverageCrossoverStrategy(params)
 
     # Generate signals
     signals = strategy.generate_signals(mock_polars_data)
 
-    # Check if signals are generated correctly
-    assert signals["signal"].sum() > 0, "No buy signals generated"
-    assert (
-        signals["signal"].value_counts().filter(pl.col("signal") == 1.0)["count"][0] > 0
-    ), "No buy signals (1) generated"
-    assert (
-        signals["signal"].value_counts().filter(pl.col("signal") == 0.0)["count"][0] > 0
-    ), "No sell signals (0) generated"
-
-    # Check if the strategy generates a buy signal when short MA crosses above long MA
-    crossover_indices = signals.filter(
-        pl.col("short_mavg") > pl.col("long_mavg")
-    ).select("Date")
-    assert len(crossover_indices) > 0, "No crossover detected"
-    crossover_index = crossover_indices.row(0)[0]
-    assert (
-        signals.filter(pl.col("Date") == crossover_index)["signal"].item() == 1.0
-    ), "Buy signal not generated at crossover"
-
-    # Check if the strategy generates a sell signal when short MA crosses below long MA
-    crossunder_indices = signals.filter(
-        pl.col("short_mavg") < pl.col("long_mavg")
-    ).select("Date")
-    assert len(crossunder_indices) > 0, "No crossunder detected"
-    crossunder_index = crossunder_indices.row(-1)[0]
-    assert (
-        signals.filter(pl.col("Date") == crossunder_index)["signal"].item() == 0.0
-    ), "Sell signal not generated at crossunder"
-
-    # Check if positions are calculated correctly
+    # Ensure signals produce trades
+    assert signals["signal"].abs().sum() > 0, "No trading signals generated"
     non_zero_positions = signals.filter(pl.col("positions") != 0)
     assert len(non_zero_positions) > 0, "No position changes"
-    assert signals["positions"].abs().sum() > 0, "No position changes"

--- a/tests/test_backtester.py
+++ b/tests/test_backtester.py
@@ -28,7 +28,7 @@ from quant_trading_strategy_backtester.strategies.pairs_trading import (
     [
         (
             MovingAverageCrossoverStrategy,
-            {"short_window": 5, "long_window": 20},
+            {},
             "mock_polars_data",
         ),
         (MeanReversionStrategy, {"window": 5, "std_dev": 2.0}, "mock_polars_data"),
@@ -63,7 +63,7 @@ def test_backtester_initialisation(
     [
         (
             MovingAverageCrossoverStrategy,
-            {"short_window": 5, "long_window": 20},
+            {},
             "mock_polars_data",
         ),
         (MeanReversionStrategy, {"window": 5, "std_dev": 2.0}, "mock_polars_data"),
@@ -95,7 +95,7 @@ def test_backtester_run(
     [
         (
             MovingAverageCrossoverStrategy,
-            {"short_window": 5, "long_window": 20},
+            {},
             "mock_polars_data",
         ),
         (MeanReversionStrategy, {"window": 5, "std_dev": 2.0}, "mock_polars_data"),
@@ -126,7 +126,7 @@ def test_backtester_get_performance_metrics(
 @pytest.mark.parametrize(
     "strategy_class,params",
     [
-        (MovingAverageCrossoverStrategy, {"short_window": 5, "long_window": 20}),
+        (MovingAverageCrossoverStrategy, {}),
         (MeanReversionStrategy, {"window": 5, "std_dev": 2.0}),
         (
             PairsTradingStrategy,
@@ -165,7 +165,7 @@ def test_backtester_with_invalid_data(
 @pytest.mark.parametrize(
     "strategy_class,params",
     [
-        (MovingAverageCrossoverStrategy, {"short_window": 5, "long_window": 20}),
+        (MovingAverageCrossoverStrategy, {}),
         (MeanReversionStrategy, {"window": 5, "std_dev": 2.0}),
         (
             PairsTradingStrategy,
@@ -189,6 +189,9 @@ def test_backtester_with_insufficient_data_all_strategies(
         insufficient_data = pl.DataFrame(
             {
                 "Date": dates,
+                "Open": [100, 101],
+                "High": [101, 102],
+                "Low": [99, 100],
                 "Close": [100, 101],
             }
         )
@@ -209,7 +212,7 @@ def test_backtester_with_insufficient_data_all_strategies(
 
 
 def test_backtester_save_results(mock_db_session, mock_polars_data):
-    strategy = MovingAverageCrossoverStrategy({"short_window": 5, "long_window": 20})
+    strategy = MovingAverageCrossoverStrategy({})
     backtester = Backtester(mock_polars_data, strategy, session=mock_db_session)
     backtester.run()
 
@@ -226,7 +229,7 @@ def test_backtester_save_results(mock_db_session, mock_polars_data):
 
     assert saved_strategy is not None
     print("Saved strategy:", saved_strategy.__dict__)
-    assert saved_strategy.parameters == '{"short_window": 5, "long_window": 20}'
+    assert saved_strategy.parameters == '{}'
     assert saved_strategy.total_return is not None
 
     # Check if sharpe_ratio is either NaN or None

--- a/tests/test_strategy_preparation.py
+++ b/tests/test_strategy_preparation.py
@@ -18,7 +18,7 @@ from quant_trading_strategy_backtester.strategy_preparation import (
 @pytest.mark.parametrize(
     "strategy_type,params,tickers",
     [
-        ("Moving Average Crossover", {"short_window": 5, "long_window": 20}, "AAPL"),
+        ("Moving Average Crossover", {}, "AAPL"),
         ("Mean Reversion", {"window": 5, "std_dev": 2.0}, "AAPL"),
         (
             "Pairs Trading",
@@ -102,7 +102,7 @@ def test_optimise_single_ticker_strategy_ticker(monkeypatch):
     start_date = datetime.date(2020, 1, 1)
     end_date = datetime.date(2020, 12, 31)
     strategy_type = "Moving Average Crossover"
-    strategy_params = {"short_window": 10, "long_window": 50}
+    strategy_params = {}
 
     best_ticker = optimise_single_ticker_strategy_ticker(
         mock_top_companies, start_date, end_date, strategy_type, strategy_params
@@ -132,7 +132,7 @@ def test_prepare_single_ticker_strategy_with_optimisation(monkeypatch):
         return mock_polars_data
 
     def mock_optimise_strategy_params(*args, **kwargs):
-        return {"short_window": 15, "long_window": 60}, {"Sharpe Ratio": 1.8}
+        return {}, {"Sharpe Ratio": 1.8}
 
     monkeypatch.setattr(
         "quant_trading_strategy_backtester.strategy_preparation.get_top_sp500_companies",
@@ -154,10 +154,7 @@ def test_prepare_single_ticker_strategy_with_optimisation(monkeypatch):
     start_date = datetime.date(2020, 1, 1)
     end_date = datetime.date(2020, 12, 31)
     strategy_type = "Moving Average Crossover"
-    strategy_params = {
-        "short_window": range(5, 30, 5),
-        "long_window": range(20, 100, 10),
-    }
+    strategy_params = {}
     optimise = True
 
     data, ticker_display, optimised_params = (
@@ -170,9 +167,7 @@ def test_prepare_single_ticker_strategy_with_optimisation(monkeypatch):
     assert isinstance(ticker_display, str)
     assert ticker_display == "AAPL"
     assert isinstance(optimised_params, dict)
-    assert set(optimised_params.keys()) == {"short_window", "long_window"}
-    assert optimised_params["short_window"] == 15
-    assert optimised_params["long_window"] == 60
+    assert optimised_params == {}
 
 
 def test_prepare_single_ticker_strategy_with_optimisation_no_param_optimisation(
@@ -197,7 +192,7 @@ def test_prepare_single_ticker_strategy_with_optimisation_no_param_optimisation(
         return mock_polars_data
 
     def mock_optimise_strategy_params(*args, **kwargs):
-        return {"short_window": 15, "long_window": 60}, {"Sharpe Ratio": 1.8}
+        return {}, {"Sharpe Ratio": 1.8}
 
     monkeypatch.setattr(
         "quant_trading_strategy_backtester.strategy_preparation.get_top_sp500_companies",
@@ -215,7 +210,7 @@ def test_prepare_single_ticker_strategy_with_optimisation_no_param_optimisation(
     start_date = datetime.date(2020, 1, 1)
     end_date = datetime.date(2020, 12, 31)
     strategy_type = "Moving Average Crossover"
-    strategy_params = {"short_window": 10, "long_window": 50}
+    strategy_params = {}
     optimise = False
 
     data, ticker_display, final_params = (
@@ -228,4 +223,4 @@ def test_prepare_single_ticker_strategy_with_optimisation_no_param_optimisation(
     assert isinstance(ticker_display, str)
     assert ticker_display == "AAPL"
     assert isinstance(final_params, dict)
-    assert final_params == strategy_params  # Parameters should remain unchanged
+    assert final_params == strategy_params


### PR DESCRIPTION
## Summary
- replace moving average crossover logic with Triple EMA crossover (TEMO)
- adjust UI to request position size parameter and allow optimisation
- update tests for new TEMO strategy behaviour
- update README to mention TEMO

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68685275fb88832dbcab743fa388f2bc